### PR TITLE
Fix wooX position type

### DIFF
--- a/woox/rest/types/private_position.go
+++ b/woox/rest/types/private_position.go
@@ -11,7 +11,7 @@ type Position struct {
 	Fee24H           float64 `json:"fee_24_h"`
 	MarkPrice        float64 `json:"mark_price"`
 	EstLiqPrice      float64 `json:"est_liq_price"`
-	Timestamp        string  `json:"timestamp"`
+	Timestamp        float64  `json:"timestamp"`
 }
 
 type GetOnePositionInfo struct {

--- a/woox/rest/types/private_position.go
+++ b/woox/rest/types/private_position.go
@@ -11,7 +11,7 @@ type Position struct {
 	Fee24H           float64 `json:"fee_24_h"`
 	MarkPrice        float64 `json:"mark_price"`
 	EstLiqPrice      float64 `json:"est_liq_price"`
-	Timestamp        float64  `json:"timestamp"`
+	Timestamp        int64  `json:"timestamp"`
 }
 
 type GetOnePositionInfo struct {


### PR DESCRIPTION
I have the error
`json: cannot unmarshal number into Go struct field Position.data.positions.timestamp of type string`

https://docs.woo.org/#get-all-position-info-new
Documents show this is not a string but a int64

`{
    "success": true,
    "data": {
        "positions": [
            {
                "symbol": "0_symbol",
                "holding": 1,
                "pendingLongQty": 0,
                "pendingShortQty": 1,
                "settlePrice": 1,
                "averageOpenPrice": 1,
                "pnl24H": 1,
                "fee24H": 1,
                "markPrice": 1,
                "estLiqPrice": 1,
                "timestamp": 12321321
            }
        ]
    },
    "timestamp": 1673323880342
}`

This should fix it, but can not test locally